### PR TITLE
fs_mgr: Skip bootloader status check during remounts

### DIFF
--- a/fs_mgr/fs_mgr_remount.cpp
+++ b/fs_mgr/fs_mgr_remount.cpp
@@ -629,11 +629,6 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
     }
 
-    if (android::base::GetProperty("ro.boot.verifiedbootstate", "") != "orange") {
-        LOG(ERROR) << "Device must be bootloader unlocked";
-        return EXIT_FAILURE;
-    }
-
     // Start a threadpool to service waitForService() callbacks as
     // fs_mgr_overlayfs_* might call waitForService() to get the image service.
     android::ProcessState::self()->startThreadPool();


### PR DESCRIPTION
Some bootloaders don't even set verifiedbootstate.

Change-Id: Ic1fd834344db3277939e8b89baeeb8fd239067a7